### PR TITLE
Update deploy-local.sh to use ujunox as the default denom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Whoami
 
-This is an adaptation of the cw-nfts onchain metadata contract to allow for listing of usernames on multiple services via NFT metadata.
+This is an adaptation of the cw-nfts onchain metadata contract to
+allow for listing of usernames on multiple services via NFT metadata.
 
 ```rust
 pub struct Metadata {
@@ -20,15 +21,23 @@ pub struct Metadata {
 
 ## Dev quickstart
 
-Run a juno node in docker, using the default docker compose file. Its node name should be `juno_node_1`.
+Run a juno node in docker, using the default docker compose file. Its
+node name should be `juno_node_1`.
 
-It will log an address as it starts, copy this: `juno1zxn...` so that it can be used to init the contract:
+It will log an address as it starts, copy this: `juno10j9...` so that
+it can be used to init the contract:
 
-    ./deploy_local.sh juno1zxn...
+```
+bash scripts/deploy_local.sh juno10j9gpw9t4jsz47qgnkvl5n3zlm2fz72k67rxsg
+```
+
+To use the account configured by the deploy script import the account
+in `default-account.txt` into your keplr wallet.
 
 ## Mapping address -> username
 
-There is an additional query message that allows for an owner set alias to be returned.
+There is an additional query message that allows for an owner set
+alias to be returned.
 
 ```rust
 PreferredAlias { address: String }
@@ -44,13 +53,16 @@ pub struct PreferredAliasResponse {
 }
 ```
 
-Its default behaviour is to return the last NFT in the list owned by the address (LILO). Alternatively, the user can set a preferred alias.
+Its default behaviour is to return the last NFT in the list owned by
+the address (LILO). Alternatively, the user can set a preferred alias.
 
 ### Setting a preferred alias
 
 An owner might have multiple NFTs.
 
-Setting a preferred alias is done via a new `ExecuteMsg` variant. On `burn`, `transfer_nft` or `send_nft`, this entry will be cleared from storage.
+Setting a preferred alias is done via a new `ExecuteMsg` variant. On
+`burn`, `transfer_nft` or `send_nft`, this entry will be cleared from
+storage.
 
 ```rust
 UpdatePreferredAlias {
@@ -60,7 +72,8 @@ UpdatePreferredAlias {
 
 ### Other query strategies
 
-It is possible also to use `token_info` and pass in a limit of 1, to match the default behaviour of the `PreferredAlias` query message.
+It is possible also to use `token_info` and pass in a limit of 1, to
+match the default behaviour of the `PreferredAlias` query message.
 
 ```rust
 Tokens {
@@ -81,4 +94,7 @@ OwnerOf {
 },
 ```
 
-The mapping of `username -> address` is in practice simply the link between `token_id` (the string username) and the `owner`. As/when the username is transferred or sold, this is updated with no additional computation required.
+The mapping of `username -> address` is in practice simply the link
+between `token_id` (the string username) and the `owner`. As/when the
+username is transferred or sold, this is updated with no additional
+computation required.

--- a/default-account.txt
+++ b/default-account.txt
@@ -1,0 +1,11 @@
+- name: default-account
+  type: local
+  address: juno10j9gpw9t4jsz47qgnkvl5n3zlm2fz72k67rxsg
+  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A2/eXrCgEB5XuHw/fD8QgCKZfAuHQWwpOphdlV6CTieC"}'
+  mnemonic: ""
+
+
+**Important** write this mnemonic phrase in a safe place.
+It is the only way to recover your account if you ever forget your password.
+
+siren window salt bullet cream letter huge satoshi fade shiver permit offer happy immense wage fitness goose usual aim hammer clap about super trend

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -13,7 +13,7 @@ fi
 IMAGE_TAG="v2.0.3"
 CONTAINER_NAME="juno_whoami"
 BINARY="docker exec -i $CONTAINER_NAME junod"
-DENOM='ustake'
+DENOM='ujunox'
 CHAIN_ID='testing'
 RPC='http://localhost:26657/'
 TXFLAG="--gas-prices 0.01$DENOM --gas auto --gas-adjustment 1.3 -y -b block --chain-id $CHAIN_ID --node $RPC"
@@ -25,6 +25,7 @@ docker volume rm -f junod_data
 # run junod setup script
 docker run --rm -it \
     -e PASSWORD=xxxxxxxxx \
+    -e STAKE_TOKEN=$DENOM \
     --mount type=volume,source=junod_data,target=/root \
     ghcr.io/cosmoscontracts/juno:$IMAGE_TAG /opt/setup_junod.sh $1
 


### PR DESCRIPTION
Also updates the README to add information about the default account
and formats it so that it is more readable as plaintext.

This is needed so that tx fees can be paid properly. Without these changes accounts are given in ustake which aren't used by juno. We needed to do this in dao-dao when moving to using the juno docker container.