### PR TITLE
Subdomain paths composition

### DIFF
--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -13,7 +13,7 @@ BINARY="docker exec -i $CONTAINER_NAME junod"
 DENOM='ujunox'
 CHAIN_ID='testing'
 RPC='http://localhost:26657/'
-TXFLAG="--gas-prices 0.1$DENOM --gas auto --gas-adjustment 1.5 -y -b block --chain-id $CHAIN_ID --node $RPC"
+TXFLAG="--gas-prices 0.1$DENOM --gas auto --gas-adjustment 1.3 -y -b block --chain-id $CHAIN_ID --node $RPC"
 BLOCK_GAS_LIMIT=${GAS_LIMIT:-100000000} # should mirror mainnet
 
 echo "Building $IMAGE_TAG"

--- a/src/contract_tests.rs
+++ b/src/contract_tests.rs
@@ -80,7 +80,7 @@ mod tests {
 
         let second_check =
             validate_path_characters("jeff/vader/notable-works", "death-star-employees");
-        assert_eq!(second_check, true);
+        assert_eq!(second_check, false);
 
         let third_check = validate_path_characters("jeff//vader", "death-star-employees");
         assert_eq!(third_check, false);

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -15,7 +15,7 @@ use crate::msg::{
 use crate::query::get_paths_for_owner_and_token;
 use crate::state::{CONTRACT_INFO, MINTING_FEES_INFO, PRIMARY_ALIASES, USERNAME_LENGTH_CAP};
 use crate::utils::{
-    get_mint_fee, get_mint_response, get_number_of_owned_tokens, get_username_length,
+    get_mint_fee, get_mint_response, get_number_of_owned_tokens, get_username_length, is_path,
     path_is_valid, username_is_valid, validate_subdomain, verify_logo,
 };
 use crate::Cw721MetadataContract;
@@ -242,7 +242,7 @@ pub fn mint(
     // this is a subdomain
     // we also check for cycles
     if let Some(ref parent_token_id) = msg.extension.parent_token_id {
-        if parent_token_id == username {
+        if parent_token_id == username || is_path(parent_token_id) {
             return Err(ContractError::CycleDetected {});
         } else {
             validate_subdomain(
@@ -325,7 +325,7 @@ pub fn mint_path(
     let path = &msg.token_id.to_lowercase();
 
     // if parent_token_id is set,
-    // this is a subdomain
+    // this is a path (if not, it's invalid)
     // we also check for cycles
     // we also check that parent token isn't repeated in the path
     if let Some(ref parent_token_id) = msg.extension.parent_token_id {

--- a/src/query.rs
+++ b/src/query.rs
@@ -210,6 +210,10 @@ pub fn get_parent_nft_info(
 }
 
 // get full path by heading up through the parents
+// paths for top level names would be jeffvader/anothertoken::some-nested-path
+// paths for nested paths would be like anothertoken::some-nested-path::second-nest
+// now in the case of that second-nest path, its parent is anothertoken::some-nested-path
+// essentially once you get into :: land you are into super fun recursive times
 pub fn get_path(
     contract: Cw721MetadataContract,
     deps: Deps,
@@ -232,7 +236,7 @@ pub fn get_path(
         let parent_token = contract.tokens.load(deps.storage, &cpti)?;
 
         // clip off the front if this is a path
-        // i.e. jeffvader::employment/death-star-1 will resolve
+        // i.e. jeffvader::employment will resolve
         // so we clip off jeffvader
         // not even sure this case _can_ happen, but still
         let sanitized_parent_token_id = match parent_token.extension.parent_token_id {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,11 +86,18 @@ pub fn validate_path_characters(path: &str, parent_token_id: &str) -> bool {
     let parent_token_id_present: Regex = Regex::new(parent_token_id).unwrap();
     let fifth_check_passed = !parent_token_id_present.is_match(path);
 
+    // validity is [^\/]+[\/]{1}[^\/]+
+    // more than one slash is no bueno
+    let forward_slash_regex: Regex = Regex::new(r"/").unwrap();
+    let matches = forward_slash_regex.captures_iter(path);
+    let sixth_check_passed = matches.count() <= 1;
+
     first_check_passed
         && second_check_passed
         && third_check_passed
         && fourth_check_passed
         && fifth_check_passed
+        && sixth_check_passed
 }
 
 pub fn path_is_valid(path: &str, parent_token_id: &str) -> bool {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,9 +66,12 @@ pub fn username_is_valid(deps: Deps, username: &str) -> bool {
     username_characters_valid && username_length_valid
 }
 
+// initially we allowed paths like employment/death-star-1
+// but it makes more sense to use the fact we use :: to namespace paths
+// to always resolve the parent
 pub fn validate_path_characters(path: &str, parent_token_id: &str) -> bool {
     // first check for any characters _other than_ allowed characters
-    let invalid_characters: Regex = Regex::new(r"[^a-z0-9_\-/]").unwrap();
+    let invalid_characters: Regex = Regex::new(r"[^a-z0-9_\-]").unwrap();
     let first_check_passed = !invalid_characters.is_match(path);
 
     // then check for invalid sequence of hyphens or underscores
@@ -76,28 +79,21 @@ pub fn validate_path_characters(path: &str, parent_token_id: &str) -> bool {
     let invalid_hyphens_underscores: Regex = Regex::new(r"[_\-/]{2,}").unwrap();
     let second_check_passed = !invalid_hyphens_underscores.is_match(path);
 
-    let leading_forward_slash: Regex = Regex::new(r"^[_\-/]").unwrap();
-    let third_check_passed = !leading_forward_slash.is_match(path);
-
-    let trailing_forward_slash: Regex = Regex::new(r"[_\-/]$").unwrap();
-    let fourth_check_passed = !trailing_forward_slash.is_match(path);
-
     // check parent token isn't in there
     let parent_token_id_present: Regex = Regex::new(parent_token_id).unwrap();
-    let fifth_check_passed = !parent_token_id_present.is_match(path);
+    let third_check_passed = !parent_token_id_present.is_match(path);
 
-    // validity is [^\/]+[\/]{1}[^\/]+
-    // more than one slash is no bueno
-    let forward_slash_regex: Regex = Regex::new(r"/").unwrap();
-    let matches = forward_slash_regex.captures_iter(path);
-    let sixth_check_passed = matches.count() <= 1;
+    let leading_special_chars: Regex = Regex::new(r"^[_\-]").unwrap();
+    let fourth_check_passed = !leading_special_chars.is_match(path);
+
+    let trailing_special_chars: Regex = Regex::new(r"[_\-]$").unwrap();
+    let fifth_check_passed = !trailing_special_chars.is_match(path);
 
     first_check_passed
         && second_check_passed
         && third_check_passed
         && fourth_check_passed
         && fifth_check_passed
-        && sixth_check_passed
 }
 
 pub fn path_is_valid(path: &str, parent_token_id: &str) -> bool {
@@ -112,6 +108,9 @@ pub fn is_path(token_id: &str) -> bool {
 }
 
 // check whether the offered token id matches the namespace
+// this specifically checks if it is at the beginning of the string
+// however note we actually do not allow the parent id anywhere in
+// the substring thanks to the validator fn - this prevents cycles
 pub fn namespace_in_path(token_id: &str, parent_token_id: &str) -> bool {
     let namespace_regex = format!("^{}", parent_token_id);
     let has_namespace: Regex = Regex::new(&namespace_regex).unwrap();


### PR DESCRIPTION
Fixes #61 

This makes it impossible to break up paths with any characters like `/` that are not allowed in normal tokens. In addition, the resolver has been updated to deal with this higher level of potential nesting.

What this means is that in effect all paths are now simply a pair of `parent::child` meaning that all sub-paths can be fluently composed into a single resolvable path.

Tests have been added for nesting and clearing, as well as to ensure that base tokens are themselves not nested under a path, as this could introduce a cycle.