### PR TITLE
Fix nested paths query

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ computation required.
 
 Although it is complex to do UI for, and most users don't seem to need it, subdomains are supported in this first version. We call them Paths.
 
+It is important to note that while minting is governed by a fee, Paths can be minted for free (other than gas etc) by the owner of the Base Token.
+
 - Minting is done via `MintPath`
 - Base name tokens that are _not_ Paths can be queried with `BaseTokens`
 - Paths (and not Base tokens) can be queried with `Paths`

--- a/README.md
+++ b/README.md
@@ -119,18 +119,23 @@ between `token_id` (the string username) and the `owner`. As/when the
 username is transferred or sold, this is updated with no additional
 computation required.
 
-## Subdomains
+## Paths
 
-Although it is complex to do UI for, and most users don't seem to need it, subdomains are supported in this first version.
+Although it is complex to do UI for, and most users don't seem to need it, subdomains are supported in this first version. We call them Paths.
+
+- Minting is done via `MintPath`
+- Base name tokens that are _not_ Paths can be queried with `BaseTokens`
+- Paths (and not Base tokens) can be queried with `Paths`
+- Paths nested under a token can be queried with `PathsForToken`
 
 ### Getting a full path
 
 For resolving a full path, selecting a parent, or working with subdomains, you will want to resolve the tree of `parent_token_id`s that a token has.
 
-The query for this is `GetPath`:
+The query for this is `GetFullPath`:
 
 ```rust
-GetPath { token_id: String }
+GetFullPath { token_id: String }
 ```
 
 This returns:

--- a/src/contract_tests.rs
+++ b/src/contract_tests.rs
@@ -1343,6 +1343,30 @@ mod tests {
             }
         );
 
+        // CHECK: 1 direct subpaths under deeper::secret-plans minted
+        let secret_plans_nested_token_query: TokensResponse = from_binary(
+            &entry::query(
+                deps.as_ref(),
+                mock_env(),
+                QueryMsg::PathsForToken {
+                    owner: String::from("jeff-vader"),
+                    token_id: prepended_path_id,
+                    start_after: None,
+                    limit: None,
+                },
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        // expect response to be ["deeper::secret-plans::death-star-1"]
+        assert_eq!(
+            secret_plans_nested_token_query,
+            TokensResponse {
+                tokens: [prepended_path_id_2.clone()].to_vec()
+            }
+        );
+
         // CHECK: finally, check the whole path
         let secret_plans_path_query: GetPathResponse = from_binary(
             &entry::query(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -112,7 +112,11 @@ pub fn is_path(token_id: &str) -> bool {
 // however note we actually do not allow the parent id anywhere in
 // the substring thanks to the validator fn - this prevents cycles
 pub fn namespace_in_path(token_id: &str, parent_token_id: &str) -> bool {
-    let namespace_regex = format!("^{}", parent_token_id);
+    // okay so this is meant to identify a namespace
+    // as part of a longer path
+    // as such there must be _at least_ one more character
+    // after the namespace. moreover, it _should be a separator_, '::'
+    let namespace_regex = format!("^{}::", parent_token_id);
     let has_namespace: Regex = Regex::new(&namespace_regex).unwrap();
     has_namespace.is_match(token_id)
 }


### PR DESCRIPTION
In the case that a path was nested underneath another path, the nested paths query was returning the token id passed in as well as the token ids nested underneath. This fixes that, and also tidies up the README.