### PR TITLE
Add PGP Public Key field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "whoami"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whoami"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Alex Lynham <alex@lynh.am>"]
 edition = "2018"
 description = "NFT based metadata for PFP/user directory purposes"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pub struct Metadata {
     pub validator_operator_address: Option<String>,
     pub contract_address: Option<String>, // marks this as executable
     pub parent_token_id: Option<String>, // for paths/nested tokens
+    pub pgp_public_key: Option<String>, // exactly what you think it is
 }
 ```
 

--- a/schema/all_nft_info_response.json
+++ b/schema/all_nft_info_response.json
@@ -214,6 +214,13 @@
             "null"
           ]
         },
+        "pgp_public_key": {
+          "description": "A public key",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "public_bio": {
           "type": [
             "string",

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -476,6 +476,13 @@
             "null"
           ]
         },
+        "pgp_public_key": {
+          "description": "A public key",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "public_bio": {
           "type": [
             "string",

--- a/schema/nft_info_response.json
+++ b/schema/nft_info_response.json
@@ -145,6 +145,13 @@
             "null"
           ]
         },
+        "pgp_public_key": {
+          "description": "A public key",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "public_bio": {
           "type": [
             "string",

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -7,7 +7,7 @@ then
 fi
 
 # pinched and adapted from DA0DA0
-IMAGE_TAG=${2:-"v2.1.0"}
+IMAGE_TAG=${2:-"v2.3.0-beta"}
 CONTAINER_NAME="juno_whoami"
 BINARY="docker exec -i $CONTAINER_NAME junod"
 DENOM='ujunox'
@@ -97,7 +97,7 @@ WHOAMI_INIT='{
   "username_length_cap": 20
 }'
 echo "$WHOAMI_INIT" | jq .
-$BINARY tx wasm instantiate $CONTRACT_CODE "$WHOAMI_INIT" --from "validator" --label "whoami NFT nameservice" $TXFLAG
+$BINARY tx wasm instantiate $CONTRACT_CODE "$WHOAMI_INIT" --from "validator" --label "whoami NFT nameservice" $TXFLAG --no-admin
 RES=$?
 
 # get contract addr

--- a/src/contract_tests.rs
+++ b/src/contract_tests.rs
@@ -3,8 +3,8 @@ mod tests {
     use crate::entry;
 
     use crate::utils::{
-        is_path, namespace_in_path, remove_namespace_from_path, validate_path_characters,
-        validate_username_characters,
+        is_path, namespace_in_path, pgp_pubkey_format_is_valid, remove_namespace_from_path,
+        validate_path_characters, validate_username_characters,
     };
 
     use crate::error::ContractError;
@@ -27,6 +27,38 @@ mod tests {
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 
     // test some utils first
+    #[test]
+    fn pgp_pubkey_validator() {
+        // obviously this is not valid, but
+        // we only check a very naive format
+        let mock_pgp_key_format = "-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBFRUAGoBEACuk6ze2V2pZtScf1Ul25N2CX19AeL7sVYwnyrTYuWdG2FmJx4x
+DLTLVUazp2AEm/JhskulL/7VCZPyg7ynf+o20Tu9/6zUD7p0rnQA2k3Dz+7dKHHh
+eEsIl5EZyFy1XodhUnEIjel2nGe6f1OO7Dr3UIEQw5JnkZyqMcbLCu9sM2twFyfa
+a8JNghfjltLJs3/UjJ8ZnGGByMmWxrWQUItMpQjGr99nZf4L+IPxy2i8O8WQewB5
+fvfidBGruUYC+mTw7CusaCOQbBuZBiYduFgH8hRW97KLmHn0xzB1FV++KI7syo8q
+XGo8Un24WP40IT78XjKO
+=nUop
+-----END PGP PUBLIC KEY BLOCK-----";
+
+        let invalid_pubkey_format = "
+mQINBFRUAGoBEACuk6ze2V2pZtScf1Ul25N2CX19AeL7sVYwnyrTYuWdG2FmJx4x
+DLTLVUazp2AEm/JhskulL/7VCZPyg7ynf+o20Tu9/6zUD7p0rnQA2k3Dz+7dKHHh
+eEsIl5EZyFy1XodhUnEIjel2nGe6f1OO7Dr3UIEQw5JnkZyqMcbLCu9sM2twFyfa
+a8JNghfjltLJs3/UjJ8ZnGGByMmWxrWQUItMpQjGr99nZf4L+IPxy2i8O8WQewB5
+fvfidBGruUYC+mTw7CusaCOQbBuZBiYduFgH8hRW97KLmHn0xzB1FV++KI7syo8q
+XGo8Un24WP40IT78XjKO
+=nUop
+-----END PGP PUBLIC KEY BLOCK-----";
+
+        let first_check = pgp_pubkey_format_is_valid(mock_pgp_key_format);
+        assert_eq!(first_check, true);
+
+        let second_check = pgp_pubkey_format_is_valid(invalid_pubkey_format);
+        assert_eq!(second_check, false);
+    }
+
     #[test]
     fn username_validator() {
         let first_check = validate_username_characters("jeffvader");

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,4 +36,7 @@ pub enum ContractError {
 
     #[error("No Links Permitted for Embedded Field")]
     NoLinksPermitted {},
+
+    #[error("Format is incorrect for PGP Public Key")]
+    InvalidPgpPublicKey,
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -90,6 +90,8 @@ pub struct Metadata {
     /// somewhat like a DNS
     /// if this is None then it is a base token
     pub parent_token_id: Option<String>,
+    /// A public key
+    pub pgp_public_key: Option<String>,
 }
 
 pub type Extension = Metadata;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,11 +17,8 @@ use std::convert::TryFrom;
 // obviously if the key is the correct format
 // but still in some way incorrect it will error later
 pub fn pgp_pubkey_format_is_valid(pgp_pubkey: &str) -> bool {
-    let start_regex: Regex = Regex::new(r"^-----BEGIN PGP PUBLIC KEY BLOCK-----").unwrap();
-    let first_check_passed = start_regex.is_match(pgp_pubkey);
-
-    let end_regex: Regex = Regex::new(r"-----END PGP PUBLIC KEY BLOCK-----$").unwrap();
-    let second_check_passed = end_regex.is_match(pgp_pubkey);
+    let first_check_passed = str::starts_with(pgp_pubkey, "-----BEGIN PGP PUBLIC KEY BLOCK-----");
+    let second_check_passed = str::ends_with(pgp_pubkey, "-----END PGP PUBLIC KEY BLOCK-----");
 
     first_check_passed && second_check_passed
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,21 @@ use crate::Cw721MetadataContract;
 use regex::Regex;
 use std::convert::TryFrom;
 
+// dumb, granted
+// but a basic sense check
+// that clients don't submit something random
+// obviously if the key is the correct format
+// but still in some way incorrect it will error later
+pub fn pgp_pubkey_format_is_valid(pgp_pubkey: &str) -> bool {
+    let start_regex: Regex = Regex::new(r"^-----BEGIN PGP PUBLIC KEY BLOCK-----").unwrap();
+    let first_check_passed = start_regex.is_match(pgp_pubkey);
+
+    let end_regex: Regex = Regex::new(r"-----END PGP PUBLIC KEY BLOCK-----$").unwrap();
+    let second_check_passed = end_regex.is_match(pgp_pubkey);
+
+    first_check_passed && second_check_passed
+}
+
 // for a subdomain, we need to validate:
 // first, is the parent_token_id an actual token?
 // if it's not, throw an error


### PR DESCRIPTION
Fixes #37 

Expects the full PGP pubkey - checks formatting and accepts if valid. Mainly to stop fat-fingering at the CLI, because ATEOTD if it is invalid, it will bork at the client end.